### PR TITLE
Use Protocols Rather than ABCs for Calibre Interfaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ extend-select = ["I"]
 
 [tool.mypy]
 strict = true
+warn_redundant_casts = true
+warn_unused_ignores = true
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,7 @@ mypy = "^1.8.0"
 extend-select = ["I"]
 
 [tool.mypy]
-disallow_untyped_defs = true
-check_untyped_defs = true
-disallow_any_expr = true
+strict = true
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/calibre_template_functions/zero_pad_series.py
+++ b/src/calibre_template_functions/zero_pad_series.py
@@ -1,37 +1,42 @@
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import List, Optional, Set, SupportsRound, Union
+from typing import List, Optional, Protocol, Set, SupportsRound
 
 
-class CalibreDbApi(ABC):
-    @abstractmethod
+class CalibreDbApi(Protocol):
     def search(self, query: str) -> List[int]:
-        pass
+        ...
 
-    @abstractmethod
     def field_for(
         self, field_name: str, book_id: int, default_return: Optional[str] = None
-    ) -> Union[str, int, float, None]:
-        pass
+    ) -> Optional[str]:
+        ...
 
 
-class CalibreDb(ABC):
-    new_api: CalibreDbApi
+class CalibreDb(Protocol):
+    @property
+    def new_api(self) -> CalibreDbApi:
+        ...
 
 
-class CalibreContext(ABC):
-    arguments: List[str]
+class CalibreContext(Protocol):
+    @property
+    def arguments(self) -> List[str]:
+        ...
 
     @property
-    @abstractmethod
     def db(self) -> CalibreDb:
         ...
 
 
-class CalibreBook(ABC):
-    series: Optional[str]
-    series_index: str
+class CalibreBook(Protocol):
+    @property
+    def series(self) -> Optional[str]:
+        ...
+
+    @property
+    def series_index(self) -> str:
+        ...
 
 
 @dataclass

--- a/src/calibre_template_functions/zero_pad_series.py
+++ b/src/calibre_template_functions/zero_pad_series.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import List, Optional, Protocol, Set, SupportsRound
+from typing import List, Optional, Protocol, Set, Union
 
 
 class CalibreDbApi(Protocol):
@@ -9,7 +9,7 @@ class CalibreDbApi(Protocol):
 
     def field_for(
         self, field_name: str, book_id: int, default_return: Optional[str] = None
-    ) -> Optional[str]:
+    ) -> Optional[Union[str, float]]:
         ...
 
 
@@ -35,7 +35,7 @@ class CalibreBook(Protocol):
         ...
 
     @property
-    def series_index(self) -> str:
+    def series_index(self) -> float:
         ...
 
 
@@ -43,15 +43,18 @@ class CalibreBook(Protocol):
 class Book:
     identifier: int
     title: str
-    series: Optional[str] = None
-    series_index: Optional[Decimal] = None
+    series_index: float
+    series: Optional[str]
 
     def __hash__(self) -> int:
         return self.identifier
 
 
-def print_result(number: Decimal, zero_padding: int, decimal_places: int) -> str:
+def print_result(
+    number: Union[Decimal, float], zero_padding: int, decimal_places: int
+) -> str:
     """Print result. Integers should not show any decimal places."""
+    number = Decimal(number)
     if number % 1 == 0:
         return "{:0>{zero_padding}d}".format(int(number), zero_padding=zero_padding)
     return "{:0>{zero_padding}.{decimal_places}f}".format(
@@ -61,13 +64,15 @@ def print_result(number: Decimal, zero_padding: int, decimal_places: int) -> str
     )
 
 
-def count_decimal_places(number: SupportsRound[Decimal]) -> int:
+def count_decimal_places(number: Union[Decimal, float]) -> int:
     """Count decimal places to a max of two places"""
+    number = Decimal(number)
     return abs(int(round(number, 2).normalize().as_tuple().exponent))
 
 
-def count_whole_digits(number: Decimal) -> int:
+def count_whole_digits(number: Union[Decimal, float]) -> int:
     """Count whole digits. Minimum of one place returned, even for zero values."""
+    number = Decimal(number)
     num_tuple = number.normalize().as_tuple()
     exponent = int(num_tuple.exponent)
     digits = num_tuple.digits if exponent == 0 else num_tuple.digits[:exponent]
@@ -78,13 +83,21 @@ def get_books_in_series(calibre_db: CalibreDbApi, series_name: str) -> Set[Book]
     book_ids = calibre_db.search(f'series:"={series_name}"')
     output = set()
     for book_id in book_ids:
-        series_index = calibre_db.field_for("series_index", book_id, "")
+        title = calibre_db.field_for("title", book_id)
+        assert isinstance(title, str)
+
+        series = calibre_db.field_for("series", book_id, None)
+        assert isinstance(series, str) or series is None
+
+        series_index = calibre_db.field_for("series_index", book_id)
+        assert isinstance(series_index, float)
+
         output.add(
             Book(
                 identifier=book_id,
-                title=str(calibre_db.field_for("title", book_id, "")),
-                series=str(calibre_db.field_for("series", book_id, "")) or None,
-                series_index=Decimal(series_index) if series_index else None,
+                title=title,
+                series=series,
+                series_index=series_index,
             )
         )
     return output
@@ -97,17 +110,7 @@ def evaluate(book: CalibreBook, context: CalibreContext) -> str:
         return ""
     number = Decimal(context.arguments[0])
     calibre_db = context.db.new_api
-    books: Set[Book] = get_books_in_series(calibre_db, book.series)
-    zero_padding = max(
-        {
-            count_whole_digits(book.series_index) if book.series_index else 0
-            for book in books
-        }
-    )
-    decimal_places = max(
-        {
-            count_decimal_places(book.series_index) if book.series_index else 0
-            for book in books
-        }
-    )
+    books = get_books_in_series(calibre_db, book.series)
+    zero_padding = max({count_whole_digits(book.series_index) for book in books})
+    decimal_places = max({count_decimal_places(book.series_index) for book in books})
     return print_result(number, zero_padding, decimal_places)

--- a/tests/stubs/calibre.py
+++ b/tests/stubs/calibre.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 class Book:
     title: str
     series: Optional[str] = None
-    series_index: str = ""
+    series_index: float = 1.0
 
 
 @dataclass

--- a/tests/stubs/calibre.py
+++ b/tests/stubs/calibre.py
@@ -1,26 +1,19 @@
 from dataclasses import dataclass, field
 from typing import List, Optional
 
-from calibre_template_functions.zero_pad_series import (
-    CalibreBook,
-    CalibreContext,
-    CalibreDb,
-    CalibreDbApi,
-)
-
 
 @dataclass
-class Book(CalibreBook):
+class Book:
     title: str
     series: Optional[str] = None
     series_index: str = ""
 
 
 @dataclass
-class DbApi(CalibreDbApi):
+class DbApi:
     search_result: List[Book]
 
-    def search(self, _query: str) -> List[int]:
+    def search(self, query: str) -> List[int]:
         return [i for i, _book in enumerate(self.search_result)]
 
     def field_for(
@@ -33,12 +26,12 @@ class DbApi(CalibreDbApi):
 
 
 @dataclass
-class Db(CalibreDb):
+class Db:
     new_api: DbApi
 
 
 @dataclass
-class Context(CalibreContext):
+class Context:
     calibre_db: DbApi
     arguments: List[str] = field(default_factory=lambda: [""])
 

--- a/tests/stubs/calibre.py
+++ b/tests/stubs/calibre.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Union
 
 
 @dataclass
@@ -18,8 +18,10 @@ class DbApi:
 
     def field_for(
         self, field_name: str, book_id: int, default_return: Optional[str] = None
-    ) -> Optional[str]:
-        return_val: Optional[str] = getattr(self.search_result[book_id], field_name)
+    ) -> Optional[Union[str, float]]:
+        return_val: Optional[Union[str, float]] = getattr(
+            self.search_result[book_id], field_name
+        )
         if return_val:
             return return_val
         return default_return

--- a/tests/test_zero_pad_series.py
+++ b/tests/test_zero_pad_series.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from decimal import Decimal
 from typing import List, Set
 
 from calibre_template_functions.zero_pad_series import (
@@ -18,7 +17,7 @@ from .stubs.calibre import DbApi as CalibreDB
 
 @dataclass
 class NumberTestData:
-    dec: Decimal
+    dec: float
     expected_dec_places: int
     expected_whole_digits: int
 
@@ -38,36 +37,22 @@ class EvaluateTestData:
 
 
 number_input_list: List[NumberTestData] = [
-    NumberTestData(dec=Decimal("123"), expected_whole_digits=3, expected_dec_places=0),
-    NumberTestData(
-        dec=Decimal("0.0000"), expected_whole_digits=1, expected_dec_places=0
-    ),
-    NumberTestData(dec=Decimal("0.70"), expected_whole_digits=1, expected_dec_places=1),
-    NumberTestData(
-        dec=Decimal("0.699"), expected_whole_digits=1, expected_dec_places=1
-    ),
-    NumberTestData(dec=Decimal("0.69"), expected_whole_digits=1, expected_dec_places=2),
-    NumberTestData(
-        dec=Decimal("0.123000"), expected_whole_digits=1, expected_dec_places=2
-    ),
-    NumberTestData(
-        dec=Decimal("1.123000"), expected_whole_digits=1, expected_dec_places=2
-    ),
-    NumberTestData(
-        dec=Decimal("142.123000"), expected_whole_digits=3, expected_dec_places=2
-    ),
-    NumberTestData(
-        dec=Decimal("142.123"), expected_whole_digits=3, expected_dec_places=2
-    ),
-    NumberTestData(
-        dec=Decimal("142.0123"), expected_whole_digits=3, expected_dec_places=2
-    ),
-    NumberTestData(dec=Decimal("142"), expected_whole_digits=3, expected_dec_places=0),
-    NumberTestData(dec=Decimal("0"), expected_whole_digits=1, expected_dec_places=0),
-    NumberTestData(dec=Decimal("000"), expected_whole_digits=1, expected_dec_places=0),
-    NumberTestData(dec=Decimal("001"), expected_whole_digits=1, expected_dec_places=0),
-    NumberTestData(dec=Decimal("7"), expected_whole_digits=1, expected_dec_places=0),
-    NumberTestData(dec=Decimal("27"), expected_whole_digits=2, expected_dec_places=0),
+    NumberTestData(dec=123.0, expected_whole_digits=3, expected_dec_places=0),
+    NumberTestData(dec=0.0000, expected_whole_digits=1, expected_dec_places=0),
+    NumberTestData(dec=0.70, expected_whole_digits=1, expected_dec_places=1),
+    NumberTestData(dec=0.699, expected_whole_digits=1, expected_dec_places=1),
+    NumberTestData(dec=0.69, expected_whole_digits=1, expected_dec_places=2),
+    NumberTestData(dec=0.123000, expected_whole_digits=1, expected_dec_places=2),
+    NumberTestData(dec=1.123000, expected_whole_digits=1, expected_dec_places=2),
+    NumberTestData(dec=142.123000, expected_whole_digits=3, expected_dec_places=2),
+    NumberTestData(dec=142.123, expected_whole_digits=3, expected_dec_places=2),
+    NumberTestData(dec=142.0123, expected_whole_digits=3, expected_dec_places=2),
+    NumberTestData(dec=142.0, expected_whole_digits=3, expected_dec_places=0),
+    NumberTestData(dec=0.0, expected_whole_digits=1, expected_dec_places=0),
+    NumberTestData(dec=000.0, expected_whole_digits=1, expected_dec_places=0),
+    NumberTestData(dec=001.0, expected_whole_digits=1, expected_dec_places=0),
+    NumberTestData(dec=7.0, expected_whole_digits=1, expected_dec_places=0),
+    NumberTestData(dec=27.0, expected_whole_digits=2, expected_dec_places=0),
 ]
 
 
@@ -81,17 +66,17 @@ class TestZeroPadSeries:
             assert count_whole_digits(number.dec) == number.expected_whole_digits
 
     def test_print_result(self) -> None:
-        assert print_result(Decimal("1"), 2, 2) == "01"
-        assert print_result(Decimal("1"), 1, 2) == "1"
-        assert print_result(Decimal("14"), 0, 2) == "14"
-        assert print_result(Decimal("1.1234"), 2, 2) == "01.12"
-        assert print_result(Decimal("14.1234"), 2, 2) == "14.12"
-        assert print_result(Decimal("123.1234"), 2, 2) == "123.12"
-        assert print_result(Decimal("1.1264"), 2, 2) == "01.13"
-        assert print_result(Decimal("1.1264"), 2, 4) == "01.1264"
-        assert print_result(Decimal("1.1264"), 0, 4) == "1.1264"
-        assert print_result(Decimal("1.1264"), 1, 4) == "1.1264"
-        assert print_result(Decimal("1.12"), 1, 4) == "1.1200"
+        assert print_result(1.0, 2, 2) == "01"
+        assert print_result(1.0, 1, 2) == "1"
+        assert print_result(14.0, 0, 2) == "14"
+        assert print_result(1.1234, 2, 2) == "01.12"
+        assert print_result(14.1234, 2, 2) == "14.12"
+        assert print_result(123.1234, 2, 2) == "123.12"
+        assert print_result(1.1264, 2, 2) == "01.13"
+        assert print_result(1.1264, 2, 4) == "01.1264"
+        assert print_result(1.1264, 0, 4) == "1.1264"
+        assert print_result(1.1264, 1, 4) == "1.1264"
+        assert print_result(1.12, 1, 4) == "1.1200"
 
     def test_get_books_in_series(self) -> None:
         assertions: List[BookLookupTestData] = [
@@ -101,12 +86,12 @@ class TestZeroPadSeries:
                     CalibreBook(
                         title="Harry Potter and the Philosopher's Stone",
                         series="Harry Potter",
-                        series_index=str(1),
+                        series_index=1.0,
                     ),
                     CalibreBook(
                         title="Harry Potter and the Chamber of Secrets",
                         series="Harry Potter",
-                        series_index=str(2),
+                        series_index=2.0,
                     ),
                 ],
                 expected_output={
@@ -114,13 +99,13 @@ class TestZeroPadSeries:
                         identifier=0,
                         title="Harry Potter and the Philosopher's Stone",
                         series="Harry Potter",
-                        series_index=Decimal("1"),
+                        series_index=1.0,
                     ),
                     Book(
                         identifier=1,
                         title="Harry Potter and the Chamber of Secrets",
                         series="Harry Potter",
-                        series_index=Decimal("2"),
+                        series_index=2.0,
                     ),
                 },
             ),
@@ -131,12 +116,12 @@ class TestZeroPadSeries:
                     CalibreBook(
                         title="Sword of Destiny",
                         series="The Witcher",
-                        series_index=str(0.6999999),
+                        series_index=0.6999999,
                     ),
                     CalibreBook(
                         title="The Tower of the Swallow",
                         series="The Witcher",
-                        series_index=str(4),
+                        series_index=4.0,
                     ),
                 ],
                 expected_output={
@@ -144,13 +129,13 @@ class TestZeroPadSeries:
                         identifier=0,
                         title="Sword of Destiny",
                         series="The Witcher",
-                        series_index=Decimal("0.6999999"),
+                        series_index=0.6999999,
                     ),
                     Book(
                         identifier=1,
                         title="The Tower of the Swallow",
                         series="The Witcher",
-                        series_index=Decimal("4"),
+                        series_index=4.0,
                     ),
                 },
             ),
@@ -160,12 +145,12 @@ class TestZeroPadSeries:
                     CalibreBook(
                         title="Eye of the World",
                         series="The Wheel of Time",
-                        series_index=str(1),
+                        series_index=1.0,
                     ),
                     CalibreBook(
                         title="A Memory of Light",
                         series="The Wheel of Time",
-                        series_index=str(14),
+                        series_index=14.0,
                     ),
                 ],
                 expected_output={
@@ -173,13 +158,13 @@ class TestZeroPadSeries:
                         identifier=0,
                         title="Eye of the World",
                         series="The Wheel of Time",
-                        series_index=Decimal("1"),
+                        series_index=1.0,
                     ),
                     Book(
                         identifier=1,
                         title="A Memory of Light",
                         series="The Wheel of Time",
-                        series_index=Decimal("14"),
+                        series_index=14.0,
                     ),
                 },
             ),
@@ -204,18 +189,18 @@ class TestZeroPadSeries:
                 book=CalibreBook(
                     title="Eye of the World",
                     series="The Wheel of Time",
-                    series_index=str(1),
+                    series_index=1.0,
                 ),
                 search_results=[
                     CalibreBook(
                         title="Eye of the World",
                         series="The Wheel of Time",
-                        series_index=str(1),
+                        series_index=1.0,
                     ),
                     CalibreBook(
                         title="A Memory of Light",
                         series="The Wheel of Time",
-                        series_index=str(14),
+                        series_index=14.0,
                     ),
                 ],
                 expected_result="01",
@@ -224,18 +209,18 @@ class TestZeroPadSeries:
                 book=CalibreBook(
                     title="A Memory of Light",
                     series="The Wheel of Time",
-                    series_index=str(14),
+                    series_index=14.0,
                 ),
                 search_results=[
                     CalibreBook(
                         title="Eye of the World",
                         series="The Wheel of Time",
-                        series_index=str(1),
+                        series_index=1.0,
                     ),
                     CalibreBook(
                         title="A Memory of Light",
                         series="The Wheel of Time",
-                        series_index=str(14),
+                        series_index=14.0,
                     ),
                 ],
                 expected_result="14",
@@ -244,18 +229,18 @@ class TestZeroPadSeries:
                 book=CalibreBook(
                     title="Sword of Destiny",
                     series="The Witcher",
-                    series_index=str(0.6999999999),
+                    series_index=0.6999999999,
                 ),
                 search_results=[
                     CalibreBook(
                         title="Sword of Destiny",
                         series="The Witcher",
-                        series_index=str(0.6999999999),
+                        series_index=0.6999999999,
                     ),
                     CalibreBook(
                         title="The Tower of the Swallow",
                         series="The Witcher",
-                        series_index=str(4),
+                        series_index=4.0,
                     ),
                 ],
                 expected_result="0.7",
@@ -264,18 +249,18 @@ class TestZeroPadSeries:
                 book=CalibreBook(
                     title="The Pumpkin of Destiny",
                     series="The Pumpkin Chronicles",
-                    series_index=str(0.75),
+                    series_index=0.75,
                 ),
                 search_results=[
                     CalibreBook(
                         title="The Pumpkin of Destiny",
                         series="The Pumpkin Chronicles",
-                        series_index=str(0.75),
+                        series_index=0.75,
                     ),
                     CalibreBook(
                         title="The Seeds of Regret",
                         series="The Pumpkin Chronicles",
-                        series_index=str(328),
+                        series_index=328.0,
                     ),
                 ],
                 expected_result="000.75",
@@ -284,18 +269,18 @@ class TestZeroPadSeries:
                 book=CalibreBook(
                     title="The Seeds of Regret",
                     series="The Pumpkin Chronicles",
-                    series_index=str(328),
+                    series_index=328.0,
                 ),
                 search_results=[
                     CalibreBook(
                         title="The Pumpkin of Destiny",
                         series="The Pumpkin Chronicles",
-                        series_index=str(0.75),
+                        series_index=0.75,
                     ),
                     CalibreBook(
                         title="The Seeds of Regret",
                         series="The Pumpkin Chronicles",
-                        series_index=str(328),
+                        series_index=328.0,
                     ),
                 ],
                 expected_result="328",
@@ -304,13 +289,13 @@ class TestZeroPadSeries:
                 book=CalibreBook(
                     title="The Pumpkin of Destiny",
                     series="The Pumpkin Chronicles",
-                    series_index=str(0.254),
+                    series_index=0.254,
                 ),
                 search_results=[
                     CalibreBook(
                         title="The Pumpkin of Destiny",
                         series="The Pumpkin Chronicles",
-                        series_index=str(0.254),
+                        series_index=0.254,
                     ),
                 ],
                 expected_result="0.25",
@@ -335,7 +320,7 @@ class TestZeroPadSeries:
                 book=CalibreBook(
                     title="Eye of the World",
                     series="The Wheel of Time",
-                    series_index=str(1),
+                    series_index=1.0,
                 ),
                 context=CalibreContext(
                     calibre_db=CalibreDB(
@@ -343,12 +328,12 @@ class TestZeroPadSeries:
                             CalibreBook(
                                 title="Eye of the World",
                                 series="The Wheel of Time",
-                                series_index=str(1),
+                                series_index=1.0,
                             ),
                             CalibreBook(
                                 title="A Memory of Light",
                                 series="The Wheel of Time",
-                                series_index=str(14),
+                                series_index=14.0,
                             ),
                         ]
                     )

--- a/tests/test_zero_pad_series.py
+++ b/tests/test_zero_pad_series.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import List, Set
+from decimal import Decimal
+from typing import List, Set, Union
 
 from calibre_template_functions.zero_pad_series import (
     Book,
@@ -36,6 +37,14 @@ class EvaluateTestData:
     expected_result: str
 
 
+@dataclass
+class PrintTestData:
+    number: Union[Decimal, float]
+    zero_padding: int
+    decimal_places: int
+    expected_output: str
+
+
 number_input_list: List[NumberTestData] = [
     NumberTestData(dec=123.0, expected_whole_digits=3, expected_dec_places=0),
     NumberTestData(dec=0.0000, expected_whole_digits=1, expected_dec_places=0),
@@ -55,6 +64,31 @@ number_input_list: List[NumberTestData] = [
     NumberTestData(dec=27.0, expected_whole_digits=2, expected_dec_places=0),
 ]
 
+print_test_list = [
+    PrintTestData(1.0, 2, 2, "01"),
+    PrintTestData(1.0, 1, 2, "1"),
+    PrintTestData(14.0, 0, 2, "14"),
+    PrintTestData(1.1234, 2, 2, "01.12"),
+    PrintTestData(14.1234, 2, 2, "14.12"),
+    PrintTestData(123.1234, 2, 2, "123.12"),
+    PrintTestData(1.1264, 2, 2, "01.13"),
+    PrintTestData(1.1264, 2, 4, "01.1264"),
+    PrintTestData(1.1264, 0, 4, "1.1264"),
+    PrintTestData(1.1264, 1, 4, "1.1264"),
+    PrintTestData(1.12, 1, 4, "1.1200"),
+    PrintTestData(Decimal("1.0"), 2, 2, "01"),
+    PrintTestData(Decimal("1.0"), 1, 2, "1"),
+    PrintTestData(Decimal("14.0"), 0, 2, "14"),
+    PrintTestData(Decimal("1.1234"), 2, 2, "01.12"),
+    PrintTestData(Decimal("14.1234"), 2, 2, "14.12"),
+    PrintTestData(Decimal("123.1234"), 2, 2, "123.12"),
+    PrintTestData(Decimal("1.1264"), 2, 2, "01.13"),
+    PrintTestData(Decimal("1.1264"), 2, 4, "01.1264"),
+    PrintTestData(Decimal("1.1264"), 0, 4, "1.1264"),
+    PrintTestData(Decimal("1.1264"), 1, 4, "1.1264"),
+    PrintTestData(Decimal("1.12"), 1, 4, "1.1200"),
+]
+
 
 class TestZeroPadSeries:
     def test_count_decimal_places(self) -> None:
@@ -66,17 +100,13 @@ class TestZeroPadSeries:
             assert count_whole_digits(number.dec) == number.expected_whole_digits
 
     def test_print_result(self) -> None:
-        assert print_result(1.0, 2, 2) == "01"
-        assert print_result(1.0, 1, 2) == "1"
-        assert print_result(14.0, 0, 2) == "14"
-        assert print_result(1.1234, 2, 2) == "01.12"
-        assert print_result(14.1234, 2, 2) == "14.12"
-        assert print_result(123.1234, 2, 2) == "123.12"
-        assert print_result(1.1264, 2, 2) == "01.13"
-        assert print_result(1.1264, 2, 4) == "01.1264"
-        assert print_result(1.1264, 0, 4) == "1.1264"
-        assert print_result(1.1264, 1, 4) == "1.1264"
-        assert print_result(1.12, 1, 4) == "1.1200"
+        for assertion in print_test_list:
+            assert (
+                print_result(
+                    assertion.number, assertion.zero_padding, assertion.decimal_places
+                )
+                == assertion.expected_output
+            )
 
     def test_get_books_in_series(self) -> None:
         assertions: List[BookLookupTestData] = [


### PR DESCRIPTION
The Calibre interfaces will *never* be subclasses of the ABCs, so it's better to use protocols for type hinting our implementation.